### PR TITLE
Update arc warden internal name to match client

### DIFF
--- a/data/heroes.json
+++ b/data/heroes.json
@@ -556,7 +556,7 @@
             "localized_name": "Winter Wyvern"
         },
         {
-            "name": "npc_dota_hero_arc_warden",
+            "name": "arc_warden",
             "id": 113,
             "localized_name": "Arc Warden"
         }


### PR DESCRIPTION
Arc Warden is internally know as "arc_warden". You can see an example here http://cdn.dota2.com/apps/dota2/images/heroes/arc_warden_lg.png vs http://cdn.dota2.com/apps/dota2/images/heroes/npc_dota_hero_arc_warden_lg.png