### PR TITLE
Fixed heroes.json

### DIFF
--- a/data/heroes.json
+++ b/data/heroes.json
@@ -378,7 +378,7 @@
         {
             "name": "lycan",
             "id": 77,
-            "localized_name": "Lycanthrope"
+            "localized_name": "Lycan"
         },
         {
             "name": "brewmaster",
@@ -448,7 +448,7 @@
         {
             "name": "wisp",
             "id": 91,
-            "localized_name": "Wisp"
+            "localized_name": "IO"
         },
         {
             "name": "visage",
@@ -556,7 +556,7 @@
             "localized_name": "Winter Wyvern"
         },
         {
-            "name": "npc_dota_hero_arc_warden",
+            "name": "arc_warden",
             "id": 113,
             "localized_name": "Arc Warden"
         }


### PR DESCRIPTION
Changed Lycan, Wisp and Arc Warden to match
official Dota 2 names and your name conventions