### PR TITLE
Fixing Error 3D000 on mariaDB on OSX

### DIFF
--- a/includes/Utils/Db.php
+++ b/includes/Utils/Db.php
@@ -136,7 +136,7 @@ class Db
         }
         try {
             self::$_linkId = new PDO(
-                'mysql:host=' . $this->_server,
+                'mysql:host=' . $this->_server . ';dbname=' . $this->_database,
                 $this->_user,
                 $this->_pass,
                 array(PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES \'UTF8\'')


### PR DESCRIPTION
have no idea if this is only effecting a specific version of osx/mariadb/php but I got the error 3D000 (no database selected) upon using DB access. according to [this stackoverflow post](http://stackoverflow.com/questions/14276465/pdo-3d000-no-database-selected) specifiying the database along with the initialization this might help stuff.

shouldn't break anything, might fix other stuff.